### PR TITLE
fix compile error and the limit of ttl

### DIFF
--- a/manager/zp_manager.cc
+++ b/manager/zp_manager.cc
@@ -168,7 +168,12 @@ void StartRepl(libzp::Cluster* cluster) {
       std::string value = line_args[3];
       int ttl = -1;
       if (line_args.size() == 5) {
-        ttl = atoi(line_args[4].c_str());
+        char * end;
+        int ttl = std::strtol(line_args[4].c_str(), &end, 10);
+        if (*end != 0) {
+          std::cout << "ttl must be a integer" << std::endl;
+          continue;
+        }
       }
       s = cluster->Set(table_name, key, value, ttl);
       std::cout << s.ToString() << std::endl;

--- a/pyzeppelin/pyzeppelin.cc
+++ b/pyzeppelin/pyzeppelin.cc
@@ -1,6 +1,5 @@
 #include <Python.h>
-#include "libzp/include/zp_cluster.h"
-
+#include "libzp/include/zp_client.h"
 
 static void zeppelin_free(void *ptr)
 {


### PR DESCRIPTION
应该引用`zp_client.h`文件.

限定TTL参数为`integer`.
`leviathan@leviathan-MacBookAir:~/Code/zeppelin/zeppelin-client/manager$ ./output/bin/zp_manager 127.0.0.1 9801`
`start`
`create cluster`
`connect cluster`
`zp >> set table1 shq lsy 10`
`reset table:table1`
`OK`
`zp >> set table1 shq lsy "10"`
`ttl must be a integer`
`zp >> set table1 shq lsy test`
`ttl must be a integer`